### PR TITLE
Enable OpenGL on macOS

### DIFF
--- a/src/main/kotlin/com/xiamo/SuperSoft.kt
+++ b/src/main/kotlin/com/xiamo/SuperSoft.kt
@@ -4,6 +4,7 @@ import com.xiamo.event.EvenManager
 import com.xiamo.module.ModuleManager
 import com.xiamo.utils.config.ConfigManager
 import net.fabricmc.api.ModInitializer
+import org.jetbrains.skiko.hostOs
 import org.slf4j.LoggerFactory
 
 object SuperSoft : ModInitializer {
@@ -16,6 +17,9 @@ object SuperSoft : ModInitializer {
 		// Proceed with mild caution.
 		logger.info("SuperSoft Loaded")
 
+		if (hostOs.isMacOS) {
+			System.setProperty("skiko.macos.opengl.enabled", "true")
+		}
 
 		EvenManager
 		ModuleManager


### PR DESCRIPTION
在 macOS 上启用了 OpenGL。
但由于苹果放弃对 OpenGL 支持，部分渲染问题待修复。