### PR TITLE
fix(ui): fix Compose rendering bounds on macOS

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/com/xiamo/gui/ComposeScreen.kt
+++ b/src/main/kotlin/com/xiamo/gui/ComposeScreen.kt
@@ -81,9 +81,13 @@ open class ComposeScreen(val text: Text) : Screen(text) {
         composeScene?.size = IntSize(width, height)
     }
 
+    private fun sceneWidth() = mc.window.framebufferWidth
+
+    private fun sceneHeight() = mc.window.framebufferHeight
+
     private fun buildCompose(){
-        val frameWidth = mc.window.framebufferWidth
-        val frameHeight = mc.window.framebufferHeight
+        val frameWidth = sceneWidth()
+        val frameHeight = sceneHeight()
 
         if (skiaContext != null && surface != null &&
             surface!!.width == frameWidth && surface!!.height == frameHeight) {
@@ -117,17 +121,17 @@ open class ComposeScreen(val text: Text) : Screen(text) {
     ) {
         val mc = MinecraftClient.getInstance()
 
-        if (composeScene == null) initCompose(mc.window.width,mc.window.height)
+        if (composeScene == null) initCompose(sceneWidth(), sceneHeight())
 
         if (lastScaleFactor != mc.window.scaleFactor){
             closeSkiaResources()
-            initCompose(mc.window.width,mc.window.height)
+            initCompose(sceneWidth(), sceneHeight())
             lastScaleFactor = mc.window.scaleFactor
         }
 
-        if (composeScene?.size?.width != mc.window.width || composeScene?.size?.height != mc.window.height) {
+        if (composeScene?.size?.width != sceneWidth() || composeScene?.size?.height != sceneHeight()) {
             closeSkiaResources()
-            initCompose(mc.window.width,mc.window.height)
+            initCompose(sceneWidth(), sceneHeight())
         }
         currentScale = mc.window.scaleFactor
 
@@ -159,7 +163,7 @@ open class ComposeScreen(val text: Text) : Screen(text) {
     override fun resize(client: MinecraftClient?, width: Int, height: Int) {
         closeSkiaResources()
         if (client != null) {
-            initCompose(client.window.width, client.window.height)
+            initCompose(client.window.framebufferWidth, client.window.framebufferHeight)
         }
         super.resize(client, width, height)
     }

--- a/src/main/kotlin/com/xiamo/gui/hud/HudComponent.kt
+++ b/src/main/kotlin/com/xiamo/gui/hud/HudComponent.kt
@@ -39,8 +39,8 @@ fun HudComponent(
     content: @Composable () -> Unit
 ) {
     val mc = MinecraftClient.getInstance()
-    val windowWidth = mc.window.width.toFloat()
-    val windowHeight = mc.window.height.toFloat()
+    val windowWidth = mc.window.framebufferWidth.toFloat()
+    val windowHeight = mc.window.framebufferHeight.toFloat()
 
     val isEditMode = HudEditorManager.isEditMode
 

--- a/src/main/kotlin/com/xiamo/gui/titleScreen/TitleScreen.kt
+++ b/src/main/kotlin/com/xiamo/gui/titleScreen/TitleScreen.kt
@@ -71,19 +71,19 @@ class TitleScreen : ComposeScreen(Text.of("Title Screen")) {
                 isVisiable = true
             }
             LaunchedEffect(Unit) {
-                lastWidth = MinecraftClient.getInstance().window.width
-                lastHeight = MinecraftClient.getInstance().window.height
+                lastWidth = MinecraftClient.getInstance().window.framebufferWidth
+                lastHeight = MinecraftClient.getInstance().window.framebufferHeight
                 var t = 0
                 while (true) {
                     particles.forEach { it.update() }
                     delay(16)
                     t++
-                    if (lastWidth != MinecraftClient.getInstance().window.width || lastHeight != MinecraftClient.getInstance().window.height) {
+                    if (lastWidth != MinecraftClient.getInstance().window.framebufferWidth || lastHeight != MinecraftClient.getInstance().window.framebufferHeight) {
                         particles = List(80) {
                             Particle()
                         }
-                        lastWidth = MinecraftClient.getInstance().window.width
-                        lastHeight = MinecraftClient.getInstance().window.height
+                        lastWidth = MinecraftClient.getInstance().window.framebufferWidth
+                        lastHeight = MinecraftClient.getInstance().window.framebufferHeight
                     }
                 }
             }
@@ -135,14 +135,14 @@ class TitleScreen : ComposeScreen(Text.of("Title Screen")) {
 
 
 class Particle() {
-    var x by mutableStateOf(Random.nextFloat() * MinecraftClient.getInstance().window.width)
-    var y by mutableStateOf(Random.nextFloat() * MinecraftClient.getInstance().window.height)
+    var x by mutableStateOf(Random.nextFloat() * MinecraftClient.getInstance().window.framebufferWidth)
+    var y by mutableStateOf(Random.nextFloat() * MinecraftClient.getInstance().window.framebufferHeight)
     var speed = 0.5
     var vX = (Random.nextFloat() * 2 - 1) * speed.toFloat()
     var vY = (Random.nextFloat() * 2 - 1) * speed.toFloat()
     fun update() {
-        if (x >= MinecraftClient.getInstance().window.width.toFloat() || x <= 0){vX *= -1 }
-        if (y >= MinecraftClient.getInstance().window.height.toFloat() || y <=0 ){vY *= -1 }
+        if (x >= MinecraftClient.getInstance().window.framebufferWidth.toFloat() || x <= 0){vX *= -1 }
+        if (y >= MinecraftClient.getInstance().window.framebufferHeight.toFloat() || y <=0 ){vY *= -1 }
         x += vX
         y += vY
     }
@@ -167,4 +167,3 @@ fun MenuButton(
         }
     }
 }
-

--- a/src/main/kotlin/com/xiamo/module/ComposeModule.kt
+++ b/src/main/kotlin/com/xiamo/module/ComposeModule.kt
@@ -79,9 +79,13 @@ open class ComposeModule(name : String, description : String) : Module(name,desc
         composeScene?.size = IntSize(width, height)
     }
 
+    private fun sceneWidth() = MinecraftClient.getInstance().window.framebufferWidth
+
+    private fun sceneHeight() = MinecraftClient.getInstance().window.framebufferHeight
+
     private fun buildCompose(){
-        val frameWidth = MinecraftClient.getInstance().window.framebufferWidth
-        val frameHeight = MinecraftClient.getInstance().window.framebufferHeight
+        val frameWidth = sceneWidth()
+        val frameHeight = sceneHeight()
         val mc = MinecraftClient.getInstance()
         if (skiaContext != null && surface != null &&
             surface!!.width == frameWidth && surface!!.height == frameHeight) {
@@ -105,17 +109,17 @@ open class ComposeModule(name : String, description : String) : Module(name,desc
     override fun onRender(drawContext: DrawContext) {
         val mc = MinecraftClient.getInstance()
 
-        if (composeScene == null) initCompose(mc.window.width,mc.window.height)
+        if (composeScene == null) initCompose(sceneWidth(), sceneHeight())
 
         if (lastScaleFactor != mc.window.scaleFactor.toFloat()){
             closeSkiaResources()
-            initCompose(mc.window.width,mc.window.height)
+            initCompose(sceneWidth(), sceneHeight())
             lastScaleFactor = mc.window.scaleFactor.toFloat()
         }
 
-        if (composeScene?.size?.width != mc.window.width || composeScene?.size?.height != mc.window.height) {
+        if (composeScene?.size?.width != sceneWidth() || composeScene?.size?.height != sceneHeight()) {
             closeSkiaResources()
-            initCompose(mc.window.width,mc.window.height)
+            initCompose(sceneWidth(), sceneHeight())
         }
         currentScale = mc.window.scaleFactor.toFloat()
         buildCompose()

--- a/src/main/kotlin/com/xiamo/module/modules/render/Hud.kt
+++ b/src/main/kotlin/com/xiamo/module/modules/render/Hud.kt
@@ -140,8 +140,8 @@ object Hud : ComposeModule("Hud", "界面") {
 
     @Composable
     override fun renderCompose() {
-        val screenWidth = MinecraftClient.getInstance().window.width.toFloat()
-        val screenHeight = MinecraftClient.getInstance().window.height.toFloat()
+        val screenWidth = MinecraftClient.getInstance().window.framebufferWidth.toFloat()
+        val screenHeight = MinecraftClient.getInstance().window.framebufferHeight.toFloat()
         val infiniteTransition = rememberInfiniteTransition(label = "rainbow")
         val textMeasurer = rememberTextMeasurer()
         val hueOffset by infiniteTransition.animateFloat(

--- a/src/main/kotlin/com/xiamo/module/modules/render/NameTags.kt
+++ b/src/main/kotlin/com/xiamo/module/modules/render/NameTags.kt
@@ -100,7 +100,9 @@ object NameTags : ComposeModule("NameTags", "NameTags") {
         }
 
         val fov = Math.toRadians(mc.gameRenderer.getFov(camera, tickDelta, true).toDouble()).toFloat()
-        val aspectRatio = window.width.toFloat() / window.height.toFloat()
+        val screenWidth = window.framebufferWidth.toFloat()
+        val screenHeight = window.framebufferHeight.toFloat()
+        val aspectRatio = screenWidth / screenHeight
         val halfHeight = tan(fov / 2.0f)
         val halfWidth = halfHeight * aspectRatio
         val ndcX = delta.x / -delta.z / halfWidth
@@ -108,8 +110,8 @@ object NameTags : ComposeModule("NameTags", "NameTags") {
         if (ndcX < -1f || ndcX > 1f || ndcY < -1f || ndcY > 1f) {
             return null
         }
-        val screenX = (ndcX + 1.0f) / 2.0f * window.width
-        val screenY = (ndcY + 1.0f) / 2.0f * window.height
+        val screenX = (ndcX + 1.0f) / 2.0f * screenWidth
+        val screenY = (ndcY + 1.0f) / 2.0f * screenHeight
 
         return Offset(screenX, screenY)
     }


### PR DESCRIPTION
Use framebuffer dimensions for Compose scene sizing, HUD layout, title screen particles, and NameTags projection to avoid rendering being clipped to the scaled window area on macOS.

Also update the Gradle wrapper to 9.4.0.